### PR TITLE
Add responsive typography and spacing

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;600&family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
     <style>
         /* === Глобални стилове и цветове (взети от приложението) === */
         :root {
@@ -39,7 +40,6 @@
             background-color: var(--color-bg);
             color: var(--color-text);
             line-height: 1.6;
-            padding: 1rem;
         }
 
         .container {
@@ -48,7 +48,6 @@
             background-color: var(--color-card-bg);
             border-radius: 20px;
             box-shadow: 0 10px 40px var(--color-shadow);
-            padding: 2rem 1.5rem;
         }
 
         /* === Типография и заглавия === */
@@ -60,32 +59,17 @@
             text-align: center;
         }
 
-        h1 {
-            font-size: 1.8rem;
-            margin-bottom: 0.5rem;
-        }
-
-        h2 {
-            font-size: 1.3rem;
-            margin-bottom: 1rem;
-        }
 
         p {
-            margin-bottom: 1rem;
-            font-size: 0.95rem;
         }
 
         .subtitle {
             text-align: center;
             color: var(--color-light-text);
-            font-size: 1rem;
-            margin-bottom: 2.5rem;
         }
 
         /* === Секции и карти с предимства === */
         .feature-section {
-            margin-bottom: 2.5rem;
-            padding-bottom: 2rem;
             border-bottom: 1px solid var(--color-border);
         }
         .feature-section:last-of-type {
@@ -130,7 +114,6 @@
         }
 
         .comparison-item h3 {
-            font-size: 1rem;
             font-weight: 600;
             margin-bottom: 0.5rem;
             display: flex;
@@ -139,7 +122,6 @@
         }
         
         .comparison-item p {
-            font-size: 0.9rem;
             color: var(--color-light-text);
             margin: 0;
         }
@@ -219,9 +201,6 @@
         
         /* === Media Query за по-големи екрани === */
         @media (min-width: 768px) {
-            h1 { font-size: 2.2rem; }
-            h2 { font-size: 1.5rem; }
-            .container { padding: 3rem; }
             .comparison-grid { grid-template-columns: 1fr 1fr; }
         }
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;600&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
     <!-- Chart.js библиотека за графики -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -47,7 +48,6 @@
             justify-content: center;
             align-items: flex-start;
             min-height: 100vh;
-            padding: 1rem; /* По-малко padding за мобилни */
         }
 
         .container {
@@ -56,7 +56,6 @@
             background-color: var(--color-card-bg);
             border-radius: 20px; /* По-заоблени ъгли */
             box-shadow: 0 10px 40px var(--color-shadow);
-            padding: 1.5rem;
             text-align: center;
         }
 
@@ -95,7 +94,6 @@
 
         .app-header h1 {
             font-family: 'Montserrat', sans-serif;
-            font-size: 1.5rem;
             margin: 0;
             color: var(--color-primary);
             flex-grow: 1;
@@ -103,9 +101,7 @@
         }
 
         .subtitle {
-            font-size: 0.95rem;
             color: var(--color-light-text);
-            margin-bottom: 2rem;
             text-align: center;
         }
 
@@ -130,7 +126,6 @@
         }
 
         .module-header h2 {
-            font-size: 1.1rem;
             color: var(--color-text);
             font-family: 'Montserrat', sans-serif;
             font-weight: 600;
@@ -373,7 +368,6 @@
         }
 
         #food-log-container h3 {
-            font-size: 1rem;
             margin-bottom: 0.7rem;
             color: var(--color-text);
             font-family: 'Montserrat', sans-serif;
@@ -457,7 +451,6 @@
         }
 
         .card-header h3 {
-            font-size: 1rem;
             margin: 0;
             font-family: 'Montserrat', sans-serif;
             font-weight: 600;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,41 @@
+/* Responsive typography and layout */
+
+/* Headings */
+h1 {
+  font-size: clamp(1.6rem, 5vw, 2.2rem);
+  margin-bottom: clamp(0.5rem, 2vw, 1rem);
+}
+
+h2 {
+  font-size: clamp(1.25rem, 4vw, 1.8rem);
+  margin-bottom: clamp(0.5rem, 2vw, 1rem);
+}
+
+h3 {
+  font-size: clamp(1rem, 3.5vw, 1.4rem);
+}
+
+/* Paragraphs */
+p {
+  font-size: clamp(0.9rem, 2.5vw, 1rem);
+  margin-bottom: clamp(0.8rem, 2vw, 1.2rem);
+}
+
+.subtitle {
+  font-size: clamp(0.9rem, 2.5vw, 1.1rem);
+  margin-bottom: clamp(1.5rem, 5vw, 2.5rem);
+}
+
+/* Layout adjustments for mobile */
+body {
+  padding: clamp(0.5rem, 2vw, 1rem);
+}
+
+.container {
+  padding: clamp(1rem, 4vw, 2rem);
+}
+
+.feature-section {
+  margin-bottom: clamp(1.5rem, 5vw, 2.5rem);
+  padding-bottom: clamp(1rem, 4vw, 2rem);
+}


### PR DESCRIPTION
## Summary
- use CSS clamp for heading and paragraph font sizes
- make body, container and sections use clamp-based padding and margins
- link pages to shared `style.css`

## Testing
- `node viewport-test.js` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68becc2ece84832682e88653e9eac315