### PR TITLE
Remove training term from daily activity buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,8 +763,8 @@
                     <label>Допълнителна физическа активност днес:</label>
                     <div class="activity-buttons" id="activity-buttons">
                         <button class="activity-btn active" data-value="0">Без</button>
-                        <button class="activity-btn" data-value="1">Лека тренировка</button>
-                        <button class="activity-btn" data-value="2">Интензивна тренировка</button>
+                        <button class="activity-btn" data-value="1">Лека</button>
+                        <button class="activity-btn" data-value="2">Интензивна</button>
                     </div>
                 </div>
                 <button class="module-button" id="update-daily-state-btn">Обнови нуждите за деня</button>


### PR DESCRIPTION
## Summary
- remove "тренировка" text from daily activity buttons without adding new words

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed4dfca3c83269fce3161e8b146be